### PR TITLE
Add support for m1 - (Darwin+arm64)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@ release:
   github:
     owner: mattfenwick
     name: kubectl-cyclonus
+  prerelease: auto
 builds:
   - id: kubectl-cyclonus
     goos:
@@ -12,6 +13,7 @@ builds:
     goarch:
     - amd64
     - "386"
+    - arm64
     env:
       - CGO_ENABLED=0
       - GO111MODULE=on

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -29,6 +29,17 @@ spec:
     bin: "cyclonus"
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/mattfenwick/kubectl-cyclonus/releases/download/{{ .TagName }}/kubectl-cyclonus_darwin_arm64.tar.gz" .TagName }}
+    files:
+    - from: "./kubectl-cyclonus"
+      to: "cyclonus"
+    - from: LICENSE
+      to: "."
+    bin: "cyclonus"
+  - selector:
+      matchLabels:
         os: windows
         arch: amd64
     {{addURIAndSha "https://github.com/mattfenwick/kubectl-cyclonus/releases/download/{{ .TagName }}/kubectl-cyclonus_windows_amd64.zip" .TagName }}


### PR DESCRIPTION
- Build arm64 binaries
- include Darwin arm64 release in krew.yaml
- enable prerelease support for goreleaser